### PR TITLE
specify ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.2.2'
+
 gem 'coffee-rails', '~> 4.1.0'
 gem 'enumerize'
 gem 'haml-rails'


### PR DESCRIPTION
due to heroku requires ruby version if you want to use newer ruby, currently 2.2.2.
